### PR TITLE
Choquet, UBSR; fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RiskMeasures"
 uuid = "b5a8929a-7a15-4aed-937e-21e1a404cbc5"
 authors = ["Marek Petrik <mpetrik@cs.unh.edu>, Gersi Doko, and others"]
-version = "0.6.4"
+version = "0.7"
 
 [deps]
 DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RiskMeasures"
 uuid = "b5a8929a-7a15-4aed-937e-21e1a404cbc5"
 authors = ["Marek Petrik <mpetrik@cs.unh.edu>, Gersi Doko, and others"]
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ CVaR(x, p, 0.1)  # conditional value at risk
 EVaR(x, p, 0.1)  # entropic value at risk
 ERM(x, p, 0.1)   # entropic risk measure
 expectile(x, p, 0.1)   # expectile risk measure
-UBSR(x, p, 0.1)   # utility-based shortfall risk measure with utility function u
+UBSR(x, p, z -> (z ≥ 0 ? 0 : -1), 0.1)  # utility-based shortfall risk that equals to VaR
+β = 0.1; UBSR(x, p, z -> (-exp(-β * z)), 0.1)  # utility-based shortfall risk that equals to ERM
+choquet_risk(x, p, cvar_capacity, 0.5) # choquet risk measure
+choquet_distortion_risk(x, p, cvar_distortion, 0.5) # law-invariant choquet (distortion) risk measure
 ```
 
 ### Using random variables
@@ -51,13 +54,12 @@ P = [0.1, 0.1, 0.2, 0.5, 0.1]
 x̃ = DiscreteNonParametric(X, P)
 
 VaR(x̃, 0.1)   # value at risk
-VaR(X, P, 0.1)   # value at risk
 CVaR(x̃, 0.1)  # conditional value at risk
 EVaR(x̃, 0.1)  # entropic value at risk
 ERM(x̃, 0.1)   # entropic risk measure
 expectile(x̃, 0.1)   # expectile risk measure
 UBSR(x̃, z -> (z ≥ 0 ? 0 : -1), 0.1)  # utility-based shortfall risk that equals to VaR
-UBSR(x̃, z -> (-exp(-β * z)), 0.1)  # utility-based shortfall risk that equals to ERM
+β = 0.1; UBSR(x̃, z -> (-exp(-β * z)), 0.1)  # utility-based shortfall risk that equals to ERM
 choquet_risk(x̃, cvar_capacity, 0.5) # choquet risk measure
 choquet_distortion_risk(x̃, cvar_distortion, 0.5) # law-invariant choquet (distortion) risk measure
 ```

--- a/README.md
+++ b/README.md
@@ -46,14 +46,20 @@ UBSR(x, p, 0.1)   # utility-based shortfall risk measure with utility function u
 using RiskMeasures
 using Distributions
 
-x̃ = DiscreteNonParametric([1, 5, 6, 7, 20], [0.1, 0.1, 0.2, 0.5, 0.1])
+X = [1, 5, 6, 7, 20]
+P = [0.1, 0.1, 0.2, 0.5, 0.1]
+x̃ = DiscreteNonParametric(X, P)
 
 VaR(x̃, 0.1)   # value at risk
+VaR(X, P, 0.1)   # value at risk
 CVaR(x̃, 0.1)  # conditional value at risk
 EVaR(x̃, 0.1)  # entropic value at risk
 ERM(x̃, 0.1)   # entropic risk measure
 expectile(x̃, 0.1)   # expectile risk measure
-UBSR(x̃, u, 0.1)  # utility-based shortfall risk measure with utility function u 
+UBSR(x̃, z -> (z ≥ 0 ? 0 : -1), 0.1)  # utility-based shortfall risk that equals to VaR
+UBSR(x̃, z -> (-exp(-β * z)), 0.1)  # utility-based shortfall risk that equals to ERM
+choquet_risk(x̃, cvar_capacity, 0.5) # choquet risk measure
+choquet_distortion_risk(x̃, cvar_distortion, 0.5) # law-invariant choquet (distortion) risk measure
 ```
 
 ### Using transformed random variables
@@ -61,11 +67,30 @@ UBSR(x̃, u, 0.1)  # utility-based shortfall risk measure with utility function 
 We can also compute risk measures of transformed random variables
 
 ```Julia
+using RiskMeasures
+using Distributions
+
+x̃ = DiscreteNonParametric([1, 5, 6, 7, 20], [0.1, 0.1, 0.2, 0.5, 0.1])
 VaR(5*x̃ + 10, 0.1)   # value at risk
 CVaR(x̃ - 10, 0.1)    # conditional value at risk
 ```
 
+### Using mixture models
+
+```Julia
+using RiskMeasures
+using Distributions
+
+x̃ = DiscreteNonParametric([-5, -3, 2, 7, 33], [0., 0.2, 0.1, 0.5, 0.2])
+ỹ = DiscreteNonParametric([1, 5, 6, 7, 20], [0.1, 0.1, 0.2, 0.5, 0.1])
+m̃ = MixtureModel([x̃, ỹ], [0.3, 0.7])
+
+VaR(m̃, 0.4)
+CVaR(m̃, 0.4)
+```
+
 Please see the unit tests for examples of how this package can be used to compute the risk. 
+
 
 ## Future development plans:
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,7 @@
 using Documenter, RiskMeasures
 
+DocMeta.setdocmeta!(RiskMeasures, :DocTestSetup, :(using RiskMeasures); recursive=true)
+
 makedocs(sitename="RiskMeasures.jl",
          modules = [RiskMeasures],
          format = Documenter.HTML(; prettyurls = get(ENV, "CI", nothing) == "true"),

--- a/src/RiskMeasures.jl
+++ b/src/RiskMeasures.jl
@@ -18,6 +18,6 @@ end
 
 export essinf, ERM, softmin, VaR, CVaR, EVaR, expectile, UBSR
 export choquet_risk, closure_c, cvar_capacity
-export choquet_distortion_risk, cvar_distortion
+export choquet_distortion_risk, cvar_distortion, closure_c
 
 end

--- a/src/choquet.jl
+++ b/src/choquet.jl
@@ -1,6 +1,6 @@
 """
 
-    choquet_risk(x, pmf, c, α)
+    choquet_risk(x̃, c, α)
 
 Compute the risk measure for a given choquet capacity function `c` and
 random variable `x̃`.
@@ -12,7 +12,7 @@ Compute the risk measure for a given choquet capacity function `c` and
 random variable `x` with probabilities `pmf`.
 
 The choquet capacity function `c` that returns a non-negative value
-and is parametrized by the random variable `S`, a probablily mass function `pmf`, and
+and is parametrized by the random variable `S`, a probability mass function `pmf`, and
 level `α ∈ [0,1]`.
 
 The runtime of this function can be quadratic depending on the evaluation of the

--- a/src/choquet.jl
+++ b/src/choquet.jl
@@ -1,20 +1,26 @@
 """
+
+    choquet_risk(x, pmf, c, α)
+
+Compute the risk measure for a given choquet capacity function `c` and
+random variable `x̃`.
+
+
     choquet_risk(x, pmf, c, α)
 
 Compute the risk measure for a given choquet capacity function `c` and
 random variable `x` with probabilities `pmf`.
 
 The choquet capacity function `c` that returns a non-negative value
-and is parametrized by a level `α ∈ [0,1]`.
+and is parametrized by the random variable `S`, a probablily mass function `pmf`, and
+level `α ∈ [0,1]`.
 
 The runtime of this function can be quadratic depending on the evaluation of the
 capacity function.
 """
 function choquet_risk(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, c::Function,
                       α::Real; check_inputs = true)
-
-    check_inputs && _check_α(α)
-    check_inputs && _check_pmf(x, pmf)
+    check_inputs && (_check_α(α);  _check_pmf(x, pmf))
 
     indices = sortperm(x)
     T = float(eltype(pmf))
@@ -27,6 +33,11 @@ function choquet_risk(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, c:
         c_prev = c_curr
     end
     (value = ξ'*x, pmf = ξ)
+end
+
+function choquet_risk(x̃, c, α; kwargs...)
+    supp, pmf = rv2pmf(x̃)
+    choquet_risk(supp, pmf, c, α; kwargs...)
 end
 
 
@@ -47,20 +58,39 @@ end
 
 
 """
-    cvar_capacity(S, pmf, α)
+    cvar_distortion(t, α)
 
-choquet capacity function equivalent to CVaR at level `α`.
-Returns `min(sum(pmf[S]) / α, 1)`, which is the distorted probability `g(P(S))`
-with distortion `g(t) = min(t/α, 1)`.
+Compute the choquet capacity function equivalent to CVaR at level `α`, to be used with `choquet_distortion_risk`.
 """
-function cvar_capacity(S::AbstractVector{<:Integer}, pmf::AbstractVector{<:Real}, α::Real)
-    T = float(eltype(pmf))
-    isempty(S) && return zero(T)
-    min(sum(pmf[i] for i in S) / α, one(T))
+function cvar_distortion(t::Real, α::Real)
+    t ≥ zero(t) || error("t must be non-negative")
+    
+    if zero(α) < α ≤ one(α)
+        min(t / α, one(t))
+    elseif α == zero(α) && t > zero(t)
+        one(t)
+    elseif α == zero(α) && t == zero(t)
+        zero(t)
+    else
+        error("α must be in [0,1]")
+    end
 end
 
+"""
+    cvar_capacity(S, pmf, α)
+
+Compute the choquet capacity function equivalent to CVaR at level `α`, to be used
+with `choquet_risk`. Here `S` is the list of indices into the `pmf`.
+"""
+cvar_capacity(S::AbstractVector{<:Integer}, pmf::AbstractVector{<:Real}, α::Real) = 
+    cvar_distortion(sum(pmf[i] for i in S), α)
 
 """
+    choquet_distortion_risk(x̃, g, α)
+
+Compute the choquet risk measure for a law-invariant capacity `c(A) = g(P[A])`,
+where `g : [0,1] → [0,1]` is a distortion function with `g(0) = 0` and `g(1) = 1`.
+
     choquet_distortion_risk(x, pmf, g, α)
 
 Compute the choquet risk measure for a law-invariant capacity `c(A) = g(P[A])`,
@@ -71,8 +101,7 @@ on scalars rather than index sets, and cumulative probabilities are computed onc
 """
 function choquet_distortion_risk(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real},
                                  g::Function, α::Real; check_inputs = true)
-    check_inputs && _check_α(α)
-    check_inputs && _check_pmf(x, pmf)
+    check_inputs && (_check_α(α); _check_pmf(x, pmf))
 
     indices = sortperm(x)
     T = float(eltype(pmf))
@@ -90,9 +119,9 @@ function choquet_distortion_risk(x::AbstractVector{<:Real}, pmf::AbstractVector{
 end
 
 
-"""
-    cvar_distortion(t, α)
+function choquet_distortion_risk(x̃, c, α; kwargs...)
+    supp, pmf = rv2pmf(x̃)
+    choquet_distortion_risk(supp, pmf, c, α; kwargs...)
+end
 
-Distortion function equivalent to CVaR at level `α`: `min(t / α, 1)`.
-"""
-cvar_distortion(t::Real, α::Real) = min(t / α, one(t))
+

--- a/src/choquet.jl
+++ b/src/choquet.jl
@@ -13,7 +13,7 @@ random variable `x` with probabilities `pmf`.
 
 The choquet risk measure solves
 ```math
-\\operatorname{choquet}(x, p, c, α} =
+\\operatorname{choquet}(x, p, c, α) =
 \\min \\{ x^T q \\mid
    q \\in \\Delta_n, q(\\mathcal{U}) \\le c(\\mathcal{U}, p, \\alpha), \\forall \\mathcal{U} \\}
 ```
@@ -27,7 +27,8 @@ capacity function.
 """
 function choquet_risk(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, c::Function,
                       α::Real; check_inputs = true)
-    check_inputs && (_check_α(α);  _check_pmf(x, pmf))
+    _check_α(α)
+    check_inputs && _check_pmf(x, pmf)
 
     indices = sortperm(x)
     T = float(eltype(pmf))
@@ -89,7 +90,7 @@ where `g : [0,1] × R → [0,1]` is a distortion function with `g(0, α) = 0` an
 
 The choquet distortion risk measure solves
 ```math
-\\operatorname{choquet}(x, p, c, α} =
+\\operatorname{choquet}(x, p, c, α) =
 \\min \\{ x^T q \\mid
    q \\in \\Delta_n, q(\\mathcal{U}) \\le g(p(\\mathcal{U}), \\alpha), \\forall \\mathcal{U} \\}
 ```
@@ -136,12 +137,12 @@ coherent and comonotonic, then `choquet_risk` recovers the same risk.
 using RiskMeasures
 
 x = [1,3,-5,3]
-p = [0.2,0.2,0.3,0.2]
+p = [0.3,0.2,0.3,0.2]
 α = 0.4
 
 ρ(x, p, α) = CVaR(x, p, α).value
-choquet_risk(x, p, RiskMeasures.closure_c(ρ))
-CVaR(x, p, α).value
+choquet_risk(x, p, RiskMeasures.closure_c(ρ), α)
+CVaR(x, p, α)
 ```
 """
 function closure_c(ρ::Function)

--- a/src/choquet.jl
+++ b/src/choquet.jl
@@ -11,6 +11,13 @@ random variable `x̃`.
 Compute the risk measure for a given choquet capacity function `c` and
 random variable `x` with probabilities `pmf`.
 
+The choquet risk measure solves
+```math
+\\operatorname{choquet}(x, p, c, α} =
+\\min \\{ x^T q \\mid
+   q \\in \\Delta_n, q(\\mathcal{U}) \\le c(\\mathcal{U}, p, \\alpha), \\forall \\mathcal{U} \\}
+```
+
 The choquet capacity function `c` that returns a non-negative value
 and is parametrized by the random variable `S`, a probability mass function `pmf`, and
 level `α ∈ [0,1]`.
@@ -38,22 +45,6 @@ end
 function choquet_risk(x̃, c, α; kwargs...)
     supp, pmf = rv2pmf(x̃)
     choquet_risk(supp, pmf, c, α; kwargs...)
-end
-
-
-"""
-    closure_c(ρ)
-
-Given a risk measure function `ρ`, return a closure that computes the submodular function
-`c(S) = -ρ(-1_S)` where `1_S` is the indicator vector of an index set `S`.
-"""
-function closure_c(ρ::Function)
-    function (S::AbstractVector{<:Integer}, pmf::AbstractVector{<:Real}, alpha::Real)
-        T = float(eltype(pmf))
-        one_tilde = zeros(T, length(pmf))
-        one_tilde[S] .= one(T)
-        -ρ(-one_tilde, pmf, alpha)
-    end
 end
 
 
@@ -89,19 +80,27 @@ cvar_capacity(S::AbstractVector{<:Integer}, pmf::AbstractVector{<:Real}, α::Rea
     choquet_distortion_risk(x̃, g, α)
 
 Compute the choquet risk measure for a law-invariant capacity `c(A) = g(P[A])`,
-where `g : [0,1] → [0,1]` is a distortion function with `g(0) = 0` and `g(1) = 1`.
+where `g : [0,1] × R → [0,1]` is a distortion function with `g(0, α) = 0` and `g(1, α) = 1`.
 
     choquet_distortion_risk(x, pmf, g, α)
 
 Compute the choquet risk measure for a law-invariant capacity `c(A) = g(P[A])`,
-where `g : [0,1] → [0,1]` is a distortion function with `g(0) = 0` and `g(1) = 1`.
+where `g : [0,1] × R → [0,1]` is a distortion function with `g(0, α) = 0` and `g(1, α) = 1`.
+
+The choquet distortion risk measure solves
+```math
+\\operatorname{choquet}(x, p, c, α} =
+\\min \\{ x^T q \\mid
+   q \\in \\Delta_n, q(\\mathcal{U}) \\le g(p(\\mathcal{U}), \\alpha), \\forall \\mathcal{U} \\}
+```
 
 More efficient than `choquet_risk` for law-invariant measures: `g` is evaluated
 on scalars rather than index sets, and cumulative probabilities are computed once.
 """
 function choquet_distortion_risk(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real},
                                  g::Function, α::Real; check_inputs = true)
-    check_inputs && (_check_α(α); _check_pmf(x, pmf))
+    _check_α(α)
+    check_inputs && _check_pmf(x, pmf)
 
     indices = sortperm(x)
     T = float(eltype(pmf))
@@ -125,3 +124,31 @@ function choquet_distortion_risk(x̃, c, α; kwargs...)
 end
 
 
+
+"""
+    closure_c(ρ)
+
+Given a risk function `ρ(x, pmf) -> Real`, return a closure that computes the submodular function
+`c(S, P) = -ρ(-1_S, P)` where `1_S` is the indicator vector of an index set `S`. When `ρ` is
+coherent and comonotonic, then `choquet_risk` recovers the same risk.
+
+```@example
+using RiskMeasures
+
+x = [1,3,-5,3]
+p = [0.2,0.2,0.3,0.2]
+α = 0.4
+
+ρ(x, p, α) = CVaR(x, p, α).value
+choquet_risk(x, p, RiskMeasures.closure_c(ρ))
+CVaR(x, p, α).value
+```
+"""
+function closure_c(ρ::Function)
+    function (S::AbstractVector{<:Integer}, pmf::AbstractVector{<:Real}, α::Real)
+        T = float(eltype(pmf))
+        one_tilde = zeros(T, length(pmf))
+        one_tilde[S] .= one(T)
+        -ρ(-one_tilde, pmf, α)
+    end
+end

--- a/src/choquet.jl
+++ b/src/choquet.jl
@@ -24,6 +24,13 @@ level `α ∈ [0,1]`.
 
 The runtime of this function can be quadratic depending on the evaluation of the
 capacity function.
+
+# Examples
+
+```jldoctest
+julia> choquet_risk([1, 2, 3, 4, 5], [0.2, 0.2, 0.2, 0.2, 0.2], cvar_capacity, 0.4).value
+1.5
+```
 """
 function choquet_risk(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, c::Function,
                       α::Real; check_inputs = true)
@@ -53,6 +60,13 @@ end
     cvar_distortion(t, α)
 
 Compute the choquet capacity function equivalent to CVaR at level `α`, to be used with `choquet_distortion_risk`.
+
+# Examples
+
+```jldoctest
+julia> cvar_distortion(0.2, 0.4)
+0.5
+```
 """
 function cvar_distortion(t::Real, α::Real)
     t ≥ zero(t) || error("t must be non-negative")
@@ -73,8 +87,15 @@ end
 
 Compute the choquet capacity function equivalent to CVaR at level `α`, to be used
 with `choquet_risk`. Here `S` is the list of indices into the `pmf`.
+
+# Examples
+
+```jldoctest
+julia> cvar_capacity([1], [0.2, 0.3, 0.5], 0.4)
+0.5
+```
 """
-cvar_capacity(S::AbstractVector{<:Integer}, pmf::AbstractVector{<:Real}, α::Real) = 
+cvar_capacity(S::AbstractVector{<:Integer}, pmf::AbstractVector{<:Real}, α::Real) =
     cvar_distortion(sum(pmf[i] for i in S), α)
 
 """
@@ -97,6 +118,13 @@ The choquet distortion risk measure solves
 
 More efficient than `choquet_risk` for law-invariant measures: `g` is evaluated
 on scalars rather than index sets, and cumulative probabilities are computed once.
+
+# Examples
+
+```jldoctest
+julia> choquet_distortion_risk([1, 2, 3, 4, 5], [0.2, 0.2, 0.2, 0.2, 0.2], cvar_distortion, 0.4).value
+1.5
+```
 """
 function choquet_distortion_risk(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real},
                                  g::Function, α::Real; check_inputs = true)
@@ -129,20 +157,19 @@ end
 """
     closure_c(ρ)
 
-Given a risk function `ρ(x, pmf) -> Real`, return a closure that computes the submodular function
-`c(S, P) = -ρ(-1_S, P)` where `1_S` is the indicator vector of an index set `S`. When `ρ` is
-coherent and comonotonic, then `choquet_risk` recovers the same risk.
+Given a risk function `ρ(values, pmf, α) -> Real`, return a closure that computes the submodular
+function `c(S, pmf, α) = -ρ(-1_S, pmf, α)` where `1_S` is the indicator vector of an index set `S`.
+When `ρ` is coherent and comonotonic, then `choquet_risk` recovers the same risk.
 
-```@example
-using RiskMeasures
+# Examples
 
-x = [1,3,-5,3]
-p = [0.3,0.2,0.3,0.2]
-α = 0.4
+```jldoctest
+julia> ρ(values, pmf, α) = CVaR(values, pmf, α).value;
 
-ρ(x, p, α) = CVaR(x, p, α).value
-choquet_risk(x, p, RiskMeasures.closure_c(ρ), α)
-CVaR(x, p, α)
+julia> c = closure_c(ρ);
+
+julia> choquet_risk([1, 2, 3, 4, 5], [0.2, 0.2, 0.2, 0.2, 0.2], c, 0.4).value
+1.5
 ```
 """
 function closure_c(ρ::Function)

--- a/src/cvar.jl
+++ b/src/cvar.jl
@@ -58,6 +58,13 @@ A named tuple with CVaR `value` and the `pmf` that achieves it.
 - `fast=false`: use linear-time experimental implementation 
 
 More details: <https://en.wikipedia.org/wiki/Expected_shortfall>
+
+# Examples
+
+```jldoctest
+julia> CVaR([1, 2, 3, 4, 5], [0.2, 0.2, 0.2, 0.2, 0.2], 0.4).value
+1.5
+```
 """
 function CVaR end
 

--- a/src/cvar.jl
+++ b/src/cvar.jl
@@ -3,7 +3,7 @@ using Distributions
 # linear-time implementation of CVaR
 function qCVaR!(vals::AbstractVector{<:Real}, p::AbstractVector{<:Real}, α::Real)
     T = float(eltype(vals))
-    q, _ = qql!(copy(vals), copy(p), α)
+    q, _ = qql!(Vector(vals), Vector(p), α)
     p_left =  one(T) - (sum(p[i] for i in eachindex(p) if vals[i] < q; init=zero(T)) / α)
 
     pc = zeros(T, length(p))

--- a/src/erm.jl
+++ b/src/erm.jl
@@ -13,6 +13,16 @@ Assumes a maximization problem. Using `β = 0` computes the expectation
 and `β = Inf` computes the essential infimum (smallest value with positive probability).
 
 More details: <https://en.wikipedia.org/wiki/Entropic_risk_measure>
+
+# Examples
+
+```jldoctest
+julia> ERM([1.0, 2.0, 3.0], [0.2, 0.3, 0.5], 0.0)   # β = 0 gives the expectation
+2.3
+
+julia> round(ERM([1.0, 2.0, 3.0], [0.2, 0.3, 0.5], 1.0); digits=4)
+1.9728
+```
 """
 function ERM end
 
@@ -54,6 +64,15 @@ when computing the exponential function. If not provided, the minimum value
 of `x̃` is used instead. 
 
 The value `β` must be positive.
+
+# Examples
+
+```jldoctest
+julia> round.(softmin([0.0, 1.0], [0.5, 0.5], 1.0); digits=3)
+2-element Vector{Float64}:
+ 0.731
+ 0.269
+```
 """
 function softmin end
 

--- a/src/essinf.jl
+++ b/src/essinf.jl
@@ -11,6 +11,13 @@ function essinf end
 
 Compute the essential infimum for a discrete random variable with `values` and
 the probability mass function `pmf`.
+
+# Examples
+
+```jldoctest
+julia> essinf([1.0, 2.0, 3.0], [0.0, 0.5, 0.5])
+(value = 2.0, index = 2)
+```
 """
 function essinf(values::AbstractVector{<:Real}, pmf::AbstractVector{<:Real};
                 check_inputs = true) 

--- a/src/evar.jl
+++ b/src/evar.jl
@@ -38,6 +38,13 @@ infimum, because the supremum is attained in the limit as `β → ∞`.
 See:
 Ahmadi-Javid, A. “Entropic Value-at-Risk: A New Coherent Risk Measure.” Journal of
 Optimization Theory and Applications 155(3), 2012.
+
+# Examples
+
+```jldoctest
+julia> round(EVaR([1, 2, 3, 4, 5], [0.2, 0.2, 0.2, 0.2, 0.2], 0.4).value; digits=4)
+1.2942
+```
 """
 function EVaR end
 

--- a/src/expectile.jl
+++ b/src/expectile.jl
@@ -5,7 +5,7 @@ using Distributions
     expectile(x̃, α)
 
 Compute the expectile risk measure of the random variable `x̃` with risk level
-`α ∈ (0,1)`. When `α = 1/2`, the function computes the expected value.
+`α ∈ (0,1)`. When `α = 1/2`, the function computes the expected value. 
 
     expectile(values, pmf, α; ...)
 

--- a/src/expectile.jl
+++ b/src/expectile.jl
@@ -20,6 +20,13 @@ The function solves
 ```math
 \\argmin_{x \\in \\mathbb{R}} α \\mathbb{E}[(\\tilde{x} - x)^2_+] + (1-α) \\mathbb{E}[(\tilde{x} - x)^2_-]
 ```
+
+# Examples
+
+```jldoctest
+julia> round(expectile([1.0, 2.0, 3.0, 4.0, 5.0], [0.2, 0.2, 0.2, 0.2, 0.2], 0.25).value; digits=4)
+2.3333
+```
 """
 function expectile end
 

--- a/src/general.jl
+++ b/src/general.jl
@@ -100,7 +100,7 @@ The input must satisfy `0 < α < 1` and `p` and `vals` must have the same length
 
 A named tuple with VaR `value` as a float and the `index` that achieves it.
 """
-function qql!(vals::AbstractVector{<:Real}, p::AbstractVector{<:Real}, α::Real)
+function qql!(vals::Vector{<:Real}, p::Vector{<:Real}, α::Real)
     0 < α < 1 || _bad_risk("Violated: 0 < α < 1")
     length(p) == length(vals) ||
         _bad_distribution("Violated: length(p) == length(vals)")
@@ -126,7 +126,7 @@ end
 
 
 # a function solely used to check if the stability checks work
-@stable function test_stability(x :: Integer)
+function test_stability(x :: Integer)
     if x < 0
         return float(x)
     else

--- a/src/general.jl
+++ b/src/general.jl
@@ -1,4 +1,4 @@
-using Distributions: DiscreteNonParametric, DiscreteAffineDistribution
+using Distributions: DiscreteNonParametric, DiscreteAffineDistribution, MixtureModel
 
 _bad_risk(msg::AbstractString) =
     error(msg)
@@ -35,12 +35,17 @@ end
 function rv2pmf(x̃::DiscreteAffineDistribution)
     # needs to handle location-scale separately because
     # the implementation of the pdf function in Distributions.LocationScale
-    # leads to numerrical errors
+    # leads to numerical errors
 
     sp = support(x̃.ρ)
     pmf = pdf.(x̃.ρ, sp)
     sp = @. sp * x̃.σ + x̃.μ
     (sp, pmf)
+end
+
+function rv2pmf(x̃::MixtureModel)
+    sp = support(x̃)
+    (sp, pdf.(x̃, sp))
 end
 
 # swaps the elements of vals between 

--- a/src/ubsr.jl
+++ b/src/ubsr.jl
@@ -31,6 +31,13 @@ terminate with an error.
 
 # Returns
 - A named tuple with the computed UBSR `value`.
+
+# Examples
+
+```jldoctest
+julia> round(UBSR([1.0, 2.0, 3.0], [0.2, 0.3, 0.5], z -> z, 0.0).value; digits=4)   # u(z) = z, λ = 0 gives the expectation
+2.3
+```
 """
 function UBSR end
 

--- a/src/ubsr.jl
+++ b/src/ubsr.jl
@@ -27,7 +27,7 @@ terminate with an error.
 
 # Keyword Arguments:
 - `zmin=-1e6`, `zmax=1e6`: Lower and upper bounds for the bisection search.
-- `tol=1e-7`: Tolerance for convergence of the bisection method.
+- `tol=1e-6`: Tolerance for convergence of the bisection method.
 
 # Returns
 - A named tuple with the computed UBSR `value`.

--- a/src/ubsr.jl
+++ b/src/ubsr.jl
@@ -13,12 +13,14 @@ values `x`, and pmf `p`, for a monotone function `u`, and risk-threshold `λ`.
 
 ```math
 \\operatorname{UBSR(x, p, u, λ) =
-\\sup \\{z ∈ ℝ \\mid \\mathbb{E}[u(\\tilde{x} - z)] ≥ λ \\} = \\sup \\{z ∈ ℝ \\mid g(z) ≥ λ \\}
+\\sup \\{z ∈ ℝ \\mid \\mathbb{E}[u(\\tilde{x} - z)] ≥ λ \\} =
+\\sup \\{z ∈ ℝ \\mid -g(z) \\le -λ \\}
 ```
 where
 ```math
 g(z) := \\mathbb{E}[u(\\tilde{x} - z)]
 ```
+The UBSR can be seen as the right-continuous inverse of -g
 
 If `u` is NOT monotone (non-decreasing), the `UBSR` return is undefined and may
 terminate with an error.
@@ -39,8 +41,10 @@ function UBSR(x::AbstractVector{<:Real}, p::AbstractVector{<:Real}, u::Function,
     
     g(z) = p' * u.(x .- z) # is non-increasing
 
-    g(zmin) < λ && error("zmin is too high: E[u(x - z_min)] < λ.")
-    g(zmax) > λ && error("zmax is too low: E[u(x - z_max)] > λ.")
+
+    g(zmin) < λ && (@warn("zmin is too high: E[u(x - z_min)] < λ."); return (value=-Inf,))
+    g(zmax) ≥ λ && (@warn("zmax is too low: E[u(x - z_max)] > λ."); return (value=Inf,))
+
     g(zmin) < g(zmax) && error("Function g is not monotone: $(g(zmin)) < $(g(gmax)).")
     
     # Bisection Method
@@ -50,18 +54,16 @@ function UBSR(x::AbstractVector{<:Real}, p::AbstractVector{<:Real}, u::Function,
 
         if umid ≥ λ
             zmin = zmid
-        end
-        if umid ≤ λ
+        else
             zmax = zmid
         end
     end
-    (value=(zmin + zmax) / 2,)
+    (value=zmax,)  # return the maximum because we want an upper bound
 end
 
 function UBSR(x̃, u, λ; kwargs...)
     supp, pmf = rv2pmf(x̃)
-    v1 = UBSR(supp, pmf, u, λ; kwargs...)
-    (value=v1.value,)
+    UBSR(supp, pmf, u, λ; kwargs...)
 end
 
 

--- a/src/ubsr.jl
+++ b/src/ubsr.jl
@@ -12,7 +12,7 @@ Compute the Utility Based Shortfall RiskMeasure (UBSR) for a discrete random var
 values `x`, and pmf `p`, for a monotone function `u`, and risk-threshold `λ`.
 
 ```math
-\\operatorname{UBSR(x, p, u, λ) =
+\\operatorname{UBSR}(x, p, u, λ) =
 \\sup \\{z ∈ ℝ \\mid \\mathbb{E}[u(\\tilde{x} - z)] ≥ λ \\} =
 \\sup \\{z ∈ ℝ \\mid -g(z) \\le -λ \\}
 ```
@@ -26,7 +26,7 @@ If `u` is NOT monotone (non-decreasing), the `UBSR` return is undefined and may
 terminate with an error.
 
 # Keyword Arguments:
-- `zmin=-1e6`, `zmax-1e6`: Lower and upper bounds for the bisection search.
+- `zmin=-1e6`, `zmax=1e6`: Lower and upper bounds for the bisection search.
 - `tol=1e-7`: Tolerance for convergence of the bisection method.
 
 # Returns
@@ -42,8 +42,8 @@ function UBSR(x::AbstractVector{<:Real}, p::AbstractVector{<:Real}, u::Function,
     g(z) = p' * u.(x .- z) # is non-increasing
 
 
-    g(zmin) < λ && (@warn("zmin is too high: E[u(x - z_min)] < λ."); return (value=-Inf,))
-    g(zmax) ≥ λ && (@warn("zmax is too low: E[u(x - z_max)] > λ."); return (value=Inf,))
+    g(zmin) < λ && (@warn "zmin is too high: E[u(x - z_min)] < λ." ; return (value=-Inf,))
+    g(zmax) ≥ λ && (@warn "zmax is too low: E[u(x - z_max)] > λ."; return (value=Inf,))
 
     g(zmin) < g(zmax) && error("Function g is not monotone: $(g(zmin)) < $(g(gmax)).")
     

--- a/src/ubsr.jl
+++ b/src/ubsr.jl
@@ -13,14 +13,14 @@ values `x`, and pmf `p`, for a monotone function `u`, and risk-threshold `λ`.
 
 ```math
 \\operatorname{UBSR}(x, p, u, λ) =
-\\sup \\{z ∈ ℝ \\mid \\mathbb{E}[u(\\tilde{x} - z)] ≥ λ \\} =
-\\sup \\{z ∈ ℝ \\mid -g(z) \\le -λ \\}
+\\sup \\{z ∈ ℝ \\mid \\mathbb{E}[u(\\tilde{x} - z)] ≥ -λ \\} =
+\\sup \\{z ∈ ℝ \\mid -g(z) \\le λ \\}
 ```
 where
 ```math
 g(z) := \\mathbb{E}[u(\\tilde{x} - z)]
 ```
-The UBSR can be seen as the right-continuous inverse of -g
+The UBSR can be seen as the right-continuous inverse of g
 
 If `u` is NOT monotone (non-decreasing), the `UBSR` return is undefined and may
 terminate with an error.
@@ -42,8 +42,8 @@ function UBSR(x::AbstractVector{<:Real}, p::AbstractVector{<:Real}, u::Function,
     g(z) = p' * u.(x .- z) # is non-increasing
 
 
-    g(zmin) < λ && (@warn "zmin is too high: E[u(x - z_min)] < λ." ; return (value=-Inf,))
-    g(zmax) ≥ λ && (@warn "zmax is too low: E[u(x - z_max)] > λ."; return (value=Inf,))
+    g(zmin) < -λ && (@warn "zmin is too high: E[u(x - z_min)] < λ." ; return (value=-Inf,))
+    g(zmax) ≥ -λ && (@warn "zmax is too low: E[u(x - z_max)] > λ."; return (value=Inf,))
 
     g(zmin) < g(zmax) && error("Function g is not monotone: $(g(zmin)) < $(g(gmax)).")
     
@@ -52,7 +52,7 @@ function UBSR(x::AbstractVector{<:Real}, p::AbstractVector{<:Real}, u::Function,
         zmid = (zmin + zmax) / 2
         umid = g(zmid)
 
-        if umid ≥ λ
+        if umid ≥ -λ
             zmin = zmid
         else
             zmax = zmid

--- a/src/ubsr.jl
+++ b/src/ubsr.jl
@@ -36,7 +36,7 @@ function UBSR end
 
 function UBSR(x::AbstractVector{<:Real}, p::AbstractVector{<:Real}, u::Function, λ::Real;
               zmin::Float64=-1e6, zmax::Float64=1e6, tol::Float64=1e-6, check_inputs=true)
-    check_inputs && _check_pmf(p)
+    check_inputs && _check_pmf(x, p)
     zmin < zmax || error("zmin < zmax is violated")
     
     g(z) = p' * u.(x .- z) # is non-increasing
@@ -45,7 +45,7 @@ function UBSR(x::AbstractVector{<:Real}, p::AbstractVector{<:Real}, u::Function,
     g(zmin) < -λ && (@warn "zmin is too high: E[u(x - z_min)] < λ." ; return (value=-Inf,))
     g(zmax) ≥ -λ && (@warn "zmax is too low: E[u(x - z_max)] > λ."; return (value=Inf,))
 
-    g(zmin) < g(zmax) && error("Function g is not monotone: $(g(zmin)) < $(g(gmax)).")
+    g(zmin) < g(zmax) && error("Function g is not monotone: $(g(zmin)) < $(g(zmax)).")
     
     # Bisection Method
     while (zmax - zmin) > tol

--- a/src/var.jl
+++ b/src/var.jl
@@ -58,7 +58,7 @@ function VaR(values::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, α::Re
         end
         return (value = float(values[pos])::T, index = pos)
     else
-        qv = qql!(copy(values), copy(pmf), α)
+        qv = qql!(Vector(values), Vector(pmf), α)
         return (value = float(qv.value),
                 index = something(findfirst(==(qv.value), values), -1))
     end

--- a/src/var.jl
+++ b/src/var.jl
@@ -35,6 +35,13 @@ an index does not exist, when `α = 1`, then returns `index = -1`.
 
 - `check_inputs=true`: check that the inputs are valid.
 - `fast=true`: use linear-time experimental implementation
+
+# Examples
+
+```jldoctest
+julia> VaR([1, 2, 3, 4, 5], [0.2, 0.2, 0.2, 0.2, 0.2], 0.5)
+(value = 3.0, index = 3)
+```
 """
 function VaR(values::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, α::Real;
     check_inputs=true, fast = true)

--- a/src/var.jl
+++ b/src/var.jl
@@ -7,7 +7,9 @@ Risk must satisfy ``α ∈ [0,1]`` and `α=0.5` computes the median and `α=0` c
 essential infimum (smallest value with positive probability) and `α=1` returns infinity.
 
 Solves for
-``\\max \\{t ∈ \\mathbb{R} : \\mathbb{P}[x̃ < t] \\le α \\}``
+```math
+\\max \\{t ∈ \\mathbb{R} : \\mathbb{P}[x̃ < t] \\le α \\}
+```
 
 In general, this function is neither convex nor concave in the random variable x̃.
 """

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.1"
-project_hash = "f55ef8c0d67b41791ca1f3a9c4713a690b6a88dd"
+project_hash = "947059222817805f93b481bca99bf1f2ece43978"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "bbc22a9a08a0ef6460041086d8a7b27940ed4ffd"
@@ -18,6 +18,16 @@ version = "1.22.0"
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
     ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
     EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+
+[[deps.ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
+[[deps.AbstractTrees]]
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.4.5"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra", "Requires"]
@@ -92,6 +102,12 @@ version = "1.11.0"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.8"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -225,6 +241,12 @@ git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.5"
 
+[[deps.Documenter]]
+deps = ["ANSIColoredPrinters", "AbstractTrees", "Base64", "CodecZlib", "Dates", "DocStringExtensions", "Downloads", "Git", "IOCapture", "InteractiveUtils", "JSON", "Logging", "Markdown", "MarkdownAST", "Pkg", "PrecompileTools", "REPL", "RegistryInstances", "SHA", "TOML", "Test", "Unicode"]
+git-tree-sha1 = "56e9c37b5e7c3b4f080ab1da18d72d5c290e184a"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "1.17.0"
+
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
@@ -234,6 +256,12 @@ version = "1.7.0"
 git-tree-sha1 = "c49898e8438c828577f04b92fc9368c388ac783c"
 uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
 version = "1.0.7"
+
+[[deps.Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "c307cd83373868391f3ac30b41530bc5d5d05d08"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.8.1+0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -280,11 +308,35 @@ deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 version = "1.11.0"
 
+[[deps.Git]]
+deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
+git-tree-sha1 = "824a1890086880696fc908fe12a17bcf61738bd8"
+uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
+version = "1.5.0"
+
+[[deps.Git_LFS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8c66e385d631bb934ff05e76d4a566c640c8df69"
+uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
+version = "3.7.1+0"
+
+[[deps.Git_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "0dd4cfb426924210c8f42742751cbde74b27bfa3"
+uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
+version = "2.54.0+0"
+
 [[deps.HypergeometricFunctions]]
 deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
 git-tree-sha1 = "68c173f4f449de5b438ee67ed0c9c748dc31a2ec"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 version = "0.3.28"
+
+[[deps.IOCapture]]
+deps = ["Logging", "Random"]
+git-tree-sha1 = "0ee181ec08df7d7c911901ea38baf16f755114dc"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "1.0.0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -302,10 +354,27 @@ git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.7.1"
 
+[[deps.JSON]]
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "f76f7560267b840e492180f9899b472f30b88450"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "1.6.0"
+
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
+
+    [deps.JSON.weakdeps]
+    ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
+
 [[deps.JuliaSyntaxHighlighting]]
 deps = ["StyledStrings"]
 uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
 version = "1.12.0"
+
+[[deps.LazilyInitializedFields]]
+git-tree-sha1 = "0f2da712350b020bc3957f269c9caad516383ee0"
+uuid = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
+version = "1.3.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -335,6 +404,12 @@ version = "1.11.3+1"
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 version = "1.11.0"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
 
 [[deps.LineSearches]]
 deps = ["LinearAlgebra", "NLSolversBase", "NaNMath", "Printf"]
@@ -377,6 +452,12 @@ deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
+[[deps.MarkdownAST]]
+deps = ["AbstractTrees", "Markdown"]
+git-tree-sha1 = "93c718d892e73931841089cdc0e982d6dd9cc87b"
+uuid = "d0879d2d-cac2-40c8-9cee-1863dc0c7391"
+version = "0.1.3"
+
 [[deps.Missings]]
 deps = ["DataAPI"]
 git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
@@ -413,6 +494,12 @@ deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 version = "0.8.7+0"
 
+[[deps.OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+git-tree-sha1 = "57baa4b81a24c2910afbb6d853aa0685e4312bf7"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "10.3.1+0"
+
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
@@ -441,6 +528,11 @@ git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.8.1"
 
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.44.0+1"
+
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
 git-tree-sha1 = "e4cff168707d441cd6bf3ff7e4832bdf34278e4a"
@@ -451,22 +543,32 @@ weakdeps = ["StatsBase"]
     [deps.PDMats.extensions]
     StatsBaseExt = "StatsBase"
 
+[[deps.Parsers]]
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "5d5e0a78e971354b1c7bff0655d11fdc1b0e12c8"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.8.4"
+
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 version = "1.12.1"
+weakdeps = ["REPL"]
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
-
-    [deps.Pkg.weakdeps]
-    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[deps.PositiveFactorizations]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "17275485f373e6673f7e7f97051f703ed5b15b20"
 uuid = "85a6dd25-e78a-55b7-8502-1745935b8125"
 version = "0.2.4"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -496,6 +598,11 @@ version = "2.11.3"
     [deps.QuadGK.weakdeps]
     Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -505,6 +612,12 @@ version = "1.11.0"
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
+
+[[deps.RegistryInstances]]
+deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
+git-tree-sha1 = "ffd19052caf598b8653b99404058fce14828be51"
+uuid = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
+version = "0.1.0"
 
 [[deps.Requires]]
 deps = ["UUIDs"]
@@ -516,7 +629,7 @@ version = "1.3.1"
 deps = ["DispatchDoctor", "Distributions", "Optim"]
 path = ".."
 uuid = "b5a8929a-7a15-4aed-937e-21e1a404cbc5"
-version = "0.6.3"
+version = "0.6.4"
 
 [[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]
@@ -543,6 +656,10 @@ deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
 git-tree-sha1 = "c5391c6ace3bc430ca630251d02ea9687169ca68"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 version = "1.1.2"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
 
 [[deps.SortingAlgorithms]]
 deps = ["DataStructures"]
@@ -608,6 +725,22 @@ version = "1.5.2"
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
     InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
+[[deps.StructUtils]]
+deps = ["Dates", "UUIDs"]
+git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.2"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
 version = "1.11.0"
@@ -635,6 +768,11 @@ version = "1.10.0"
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 version = "1.11.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.1"
-project_hash = "b3ce2820f383c3582cc876a7ee1c3effb39c3808"
+project_hash = "f55ef8c0d67b41791ca1f3a9c4713a690b6a88dd"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "bbc22a9a08a0ef6460041086d8a7b27940ed4ffd"
@@ -516,7 +516,7 @@ version = "1.3.1"
 deps = ["DispatchDoctor", "Distributions", "Optim"]
 path = ".."
 uuid = "b5a8929a-7a15-4aed-937e-21e1a404cbc5"
-version = "0.6.0"
+version = "0.6.3"
 
 [[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,16 +1,17 @@
 [deps]
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RiskMeasures = "b5a8929a-7a15-4aed-937e-21e1a404cbc5"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-
-[compat]
-Aqua = "0.8"
 
 [sources]
 RiskMeasures = {path = ".."}
+
+[compat]
+Aqua = "0.8"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
@@ -15,3 +16,4 @@ RiskMeasures = {path = ".."}
 
 [compat]
 Aqua = "0.8"
+Documenter = "1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,39 +14,47 @@ import Random
 function compute_VaR(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, α::Real; kwargs...)
     v = VaR(x, pmf, α; fast=false, kwargs...)
     v_fast = VaR(x, pmf, α; fast=true, kwargs...)
+    v_ubsr = UBSR(x, pmf, z -> (z ≥ 0 ? 1 : 0), 1-α)
     @test v.value ≈ v_fast.value
     @test v.index < 1 || x[v.index] == v.value
     @test v.index < 1 ||x[v_fast.index] == v_fast.value
     @test v.index < 1 ? v_fast.index == v.index == -1 : true
+    @test v_ubsr.value ≈ v.value atol = 0.01
     return v
 end
 
 function compute_VaR(x̃, α; kwargs...)
     v = VaR(x̃, α; fast=false, kwargs...)
     v_fast = VaR(x̃, α; fast=true, kwargs...)
+    v_ubsr = UBSR(x̃, z -> (z ≥ 0 ? 1 : 0), 1-α)
     @test v.value ≈ v_fast.value
     @test v.value ≈ mean(v.pmf)
     @test mean(v.pmf) ≈ mean(v_fast.pmf)
+    @test v_ubsr.value ≈ v.value atol = 0.01
     return v
 end
 
 function compute_CVaR(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, α::Real; kwargs...)
     c = CVaR(x, pmf, α; fast=false, kwargs...)
     c_fast = CVaR(x, pmf, α; fast=true, kwargs...)
+    c_choquet = choquet_risk(x, pmf, cvar_capacity, α)
+    c_distortion = choquet_distortion_risk(x, pmf, cvar_distortion, α)
     @test c.value ≈ c_fast.value
     @test c.pmf ≈ c_fast.pmf atol = 0.01
-    #c_choquet = choquet_risk(x, pmf, cvar_capacity, α)
-    #@test c_choquet ≈ c.value atol = 1e-10
-    #c_distortion = choquet_distortion_risk(x, pmf, cvar_distortion, α)
-    #@test c_distortion ≈ c.value atol = 1e-10
+    @test c_choquet.value ≈ c.value atol = 1e-10
+    @test c_distortion.value ≈ c.value atol = 1e-10
     return c
 end
 
 function compute_CVaR(x̃, α; kwargs...)
     c = CVaR(x̃, α; fast=false, kwargs...)
     c_fast = CVaR(x̃, α; fast=true, kwargs...)
+    c_choquet = choquet_risk(x̃, cvar_capacity, α)
+    c_distortion = choquet_distortion_risk(x̃, cvar_distortion, α)
     @test c.value ≈ c_fast.value
     @test mean(c.pmf) ≈ mean(c_fast.pmf)
+    @test c_choquet.value ≈ c.value atol = 1e-10
+    @test c_distortion.value ≈ c.value atol = 1e-10
     return c
 end
 
@@ -62,11 +70,9 @@ function compute_EVaR(x̃, α; kwargs...)
 end
 
 function compute_expectile(x̃, α; kwargs...)
-    expectile(x̃, α; kwargs...)
-end
-
-function compute_UBSR(x, p, u, λ; kwargs...)
-    UBSR(x, p, u, λ; kwargs...)
+    v = expectile(x̃, α; kwargs...)
+    # TODO : add the comparison with
+    return v
 end
 
 @testset "ERM" begin
@@ -378,7 +384,7 @@ end
 @testset "UBSR Test" begin
     function test_UBSR(x, p)
       u = (z) -> z
-      v = compute_UBSR(x, p, u, 0)
+      v = UBSR(x, p, u, 0)
       @test v.value ≈ sum(x .* p) atol=1e-5
       dnp = DiscreteNonParametric(x, p)
       v2 = UBSR(dnp, u, 0)
@@ -387,16 +393,16 @@ end
       # ERM
       β = 0.5
       u = (z) -> (-exp(-β * z))
-      v = compute_UBSR(x, p, u, -1)
+      v = UBSR(x, p, u, -1)
       @test v.value ≈ ERM(x, p, β) atol=1e-5
       # VaR
       α = 0.9
       u = (z) -> (z ≥ 0 ? 1 : 0)
-      v = compute_UBSR(x, p, u, α)
+      v = UBSR(x, p, u, α)
       @test v.value ≈ compute_VaR(x, p, 1-α).value atol=1e-5
       # Expectile
       u = (z) -> (α * max(z, 0) - (1-α) * max(-z, 0))
-      v = compute_UBSR(x, p, u, 0)
+      v = UBSR(x, p, u, 0)
       @test v.value ≈ compute_expectile(dnp, α).value atol=1e-5
     end
     x = [1.0, 2.0, 3.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,11 @@ import Random
 import Logging
 Logging.disable_logging(Logging.Warn)
 
+## === Run the doctests embedded in the docstrings
+import Documenter
+Documenter.DocMeta.setdocmeta!(RiskMeasures, :DocTestSetup, :(using RiskMeasures); recursive=true)
+Documenter.doctest(RiskMeasures; manual=false)
+
 
 function compute_VaR(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, α::Real; kwargs...)
     v = VaR(x, pmf, α; fast=false, kwargs...)
@@ -374,7 +379,7 @@ end
     @test_throws ErrorException expectile(x̃, -1.0)
     @test_throws ErrorException expectile(x̃, 1.0)
     @test_throws ErrorException expectile(x̃, 0.0)
-    # Test monotonocity and sub/super-addativity
+    # Test monotonicity and sub/super-additivity
     X = rand(Float64, length(X))
     Y = rand(Float64, length(X))
     Z = rand(Float64, length(X))
@@ -386,7 +391,7 @@ end
     z̃ = DiscreteNonParametric(Z, p)
     σ̃ = DiscreteNonParametric(X + Z, p)
     for α ∈ 0.1:0.01:0.9
-        # check monotonocity
+        # check monotonicity
         @test compute_expectile(ỹ, α).value ≥ compute_expectile(x̃, α).value
         if α <= 0.5
             # check sub-additivity

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -374,7 +374,7 @@ end
     @test_throws ErrorException expectile(x̃, -1.0)
     @test_throws ErrorException expectile(x̃, 1.0)
     @test_throws ErrorException expectile(x̃, 0.0)
-    # Test monotonocity and subaddativity
+    # Test monotonocity and sub/super-addativity
     X = rand(Float64, length(X))
     Y = rand(Float64, length(X))
     Z = rand(Float64, length(X))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ Logging.disable_logging(Logging.Warn)
 function compute_VaR(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, α::Real; kwargs...)
     v = VaR(x, pmf, α; fast=false, kwargs...)
     v_fast = VaR(x, pmf, α; fast=true, kwargs...)
-    v_ubsr = UBSR(x, pmf, z -> (z ≥ 0 ? 1 : 0), 1-α)
+    v_ubsr = UBSR(x, pmf, z -> (z ≥ 0 ? 0 : -1), α)
     @test v.value ≈ v_fast.value
     @test v.index < 1 || x[v.index] == v.value
     @test v.index < 1 ||x[v_fast.index] == v_fast.value
@@ -31,7 +31,7 @@ end
 function compute_VaR(x̃, α; kwargs...)
     v = VaR(x̃, α; fast=false, kwargs...)
     v_fast = VaR(x̃, α; fast=true, kwargs...)
-    v_ubsr = UBSR(x̃, z -> (z ≥ 0 ? 1 : 0), 1-α)
+    v_ubsr = UBSR(x̃, z -> (z ≥ 0 ? 0 : -1), α)
     @test v.value ≈ v_fast.value
     @test v.value ≈ mean(v.pmf)
     @test mean(v.pmf) ≈ mean(v_fast.pmf)
@@ -402,14 +402,14 @@ end
       # Special cases
       # ERM
       β = 0.5
-      u = (z) -> (-exp(-β * z))
-      v = UBSR(x, p, u, -1)
+      u = z -> (-exp(-β * z))
+      v = UBSR(x, p, u, 1)
       @test v.value ≈ ERM(x, p, β) atol=1e-5
       # VaR
-      α = 0.9
-      u = (z) -> (z ≥ 0 ? 1 : 0)
+      α = 0.9001
+      u = (z) -> (z > 0 ? 0 : -1)
       v = UBSR(x, p, u, α)
-      @test v.value ≈ compute_VaR(x, p, 1-α).value atol=1e-5
+      @test v.value ≈ compute_VaR(x, p, α).value atol=1e-5
       # Expectile
       u = (z) -> (α * max(z, 0) - (1-α) * max(-z, 0))
       v = UBSR(x, p, u, 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,11 @@ using LinearAlgebra: ones
 using Distributions
 import Random
 
+## === Disable warnings
+import Logging
+Logging.disable_logging(Logging.Warn)
+
+
 function compute_VaR(x::AbstractVector{<:Real}, pmf::AbstractVector{<:Real}, α::Real; kwargs...)
     v = VaR(x, pmf, α; fast=false, kwargs...)
     v_fast = VaR(x, pmf, α; fast=true, kwargs...)
@@ -343,20 +348,25 @@ end
     @test_throws ErrorException expectile(x̃, 1.0)
     @test_throws ErrorException expectile(x̃, 0.0)
     # Test monotonocity and subaddativity
+    X = rand(Float64, length(X))
     Y = rand(Float64, length(X))
     Z = rand(Float64, length(X))
-    for i ∈ eachindex(X)
+    for i ∈ eachindex(X) # make sure that Y ≥ X
         Y[i] < X[i] && (Y[i] = X[i])
     end
+    x̃ = DiscreteNonParametric(X, p)
     ỹ = DiscreteNonParametric(Y, p)
     z̃ = DiscreteNonParametric(Z, p)
     σ̃ = DiscreteNonParametric(X + Z, p)
     for α ∈ 0.1:0.01:0.9
-        @test compute_expectile(x̃, α).value ≥ compute_expectile(ỹ, α).value
+        # check monotonocity
+        @test compute_expectile(ỹ, α).value ≥ compute_expectile(x̃, α).value
         if α <= 0.5
+            # check sub-additivity
             @test compute_expectile(σ̃, α).value + 1e-10 ≥
                 compute_expectile(x̃, α).value + compute_expectile(z̃, α).value
         else
+            # check super-additivity
             @test compute_expectile(σ̃, α).value - 1e-10 ≤
                 compute_expectile(x̃, α).value + compute_expectile(z̃, α).value
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,33 @@ function compute_expectile(x̃, α; kwargs...)
     return v
 end
 
+
+
+@testset "Mixture model test" begin
+    X = [1, 5, 6, 7, 20]
+    P = [0.1, 0.1, 0.2, 0.5, 0.1]
+    x̃ = DiscreteNonParametric(X, P)
+
+    m̃ = MixtureModel([x̃, x̃], [0.3, 0.7])
+    
+    β = 0.1
+
+    @test compute_VaR(x̃, 0.1).value ≈ compute_VaR(m̃, 0.1).value
+    @test compute_CVaR(x̃, 0.1).value ≈ compute_CVaR(m̃, 0.1).value
+    @test compute_EVaR(x̃, 0.1).value ≈ compute_EVaR(m̃, 0.1).value
+    @test ERM(x̃, 0.1) ≈ ERM(m̃, 0.1)
+    @test compute_expectile(x̃, 0.1).value ≈ compute_expectile(m̃, 0.1).value
+    @test UBSR(x̃, z -> (z ≥ 0 ? 0 : -1), 0.1).value ≈
+        UBSR(m̃, z -> (z ≥ 0 ? 0 : -1), 0.1).value
+    @test UBSR(x̃, z -> (-exp(-β * z)), 0.1).value ≈
+        UBSR(m̃, z -> (-exp(-β * z)), 0.1).value
+    @test choquet_risk(x̃, cvar_capacity, 0.5).value ≈
+        choquet_risk(m̃, cvar_capacity, 0.5).value
+    @test choquet_distortion_risk(x̃, cvar_distortion, 0.5).value ≈
+        choquet_distortion_risk(m̃, cvar_distortion, 0.5).value
+end
+
+
 @testset "ERM" begin
     X = [2.0, 5.0, 6.0, 9.0, 3.0, 1.0]
     p = [0.1, 0.1, 0.2, 0.5, 0.1, 0.0]
@@ -427,6 +454,20 @@ end
     p .= p ./ sum(p)
     test_UBSR(x, p)
 end
+
+@testset "Choquet risk capacity" begin
+    x = [1,3,-5,3]
+    p = [0.3,0.2,0.3,0.2]
+    α = 0.4
+
+    ρ(x, p, α) = CVaR(x, p, α).value
+    v1 = choquet_risk(x, p, RiskMeasures.closure_c(ρ), α)
+    v2 = CVaR(x, p, α)
+
+    @test v1.value ≈ v2.value
+    @test v1.pmf ≈ v2.pmf
+end
+
 
 @testset "Check type stability" begin
     @test_throws DispatchDoctor.TypeInstabilityError RiskMeasures.test_stability(1)


### PR DESCRIPTION
- Version bump
- Cleaned up choquet capacity
- Support for mixture random variables
- Fixed UBSR CVaR bugs and added more tests
- Fixed tests for expectile
- Implementation, test, and example for capacity_c
- Examples of function use